### PR TITLE
Update Sodaq_UBlox_GPS.cpp

### DIFF
--- a/src/Sodaq_UBlox_GPS.cpp
+++ b/src/Sodaq_UBlox_GPS.cpp
@@ -278,7 +278,7 @@ bool Sodaq_UBlox_GPS::parseGPRMC(const String & line)
             _lat = -_lat;
         }
         _lon = convertDegMinToDecDeg(getField(line, 5));
-        if (getField(line, 4) == "W") {
+        if (getField(line, 6) == "W") {
             _lon = -_lon;
         }
         _seenLatLon = true;


### PR DESCRIPTION
Small error parsing the E/W property of the GPRMC messages. It is not detecting properly the sign of the longitude for those on the west