### PR TITLE
Parse speed

### DIFF
--- a/src/Sodaq_UBlox_GPS.cpp
+++ b/src/Sodaq_UBlox_GPS.cpp
@@ -294,6 +294,10 @@ bool Sodaq_UBlox_GPS::parseGPRMC(const String & line)
 
     String time = getField(line, 1);
     String date = getField(line, 9);
+    String speed = getField(line, 7);
+
+    _speed = speed.toDouble();
+
     setDateTime(date, time);
 
     return true;

--- a/src/Sodaq_UBlox_GPS.h
+++ b/src/Sodaq_UBlox_GPS.h
@@ -34,6 +34,7 @@ public:
     double getLat() { return _lat; }
     double getLon() { return _lon; }
     double getAlt() { return _alt; }
+    double getSpeed() { return _speed; }
     double getHDOP() { return _hdop; }
     uint8_t getNumberOfSatellites() { return _numSatellites; }
     uint16_t getYear() { return (uint16_t)_yy + 2000; }         // 2016..
@@ -97,6 +98,7 @@ private:
     bool        _seenAlt;
     uint8_t     _numSatellites;
     double      _lat;
+    double      _speed;
     double      _lon;
     double      _alt;
     double      _hdop;


### PR DESCRIPTION
The speed (in knots) is now available via the getSpeed() function.
It is parsed from the $GPRMC sentence.