### PR TITLE
Add github action for CI testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 1 * * SUN'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: [3.7]
+        example:
+          - "examples/test_ublox_gps"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Cache PlatformIO
+        uses: actions/cache@v2
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+      - name: Build examples
+        env:
+          PLATFORMIO_CI_SRC: ${{ matrix.example }}
+        run: |
+          pio ci --lib="./src" --project-conf platformio.ini

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,8 @@
 
 Arduino library for using the UBlox EVA7M.
 
+[![CI](https://github.com/SodaqMoja/Sodaq_UBlox_GPS/workflows/CI/badge.svg)](https://github.com/SodaqMoja/Sodaq_UBlox_GPS/actions?query=workflow%3ACI)
+
 ## Usage
 
 Quick example:


### PR DESCRIPTION
Small github action which uses platformio to compile the source code. This could also used for the other Sodaq projects here at github. Within the strategy block easily more OS/python combinations can be automatically tested and the example array can be extended to compile multiple examples. 

The dependabot.yml will make sure the uses actions are kept up to date